### PR TITLE
Support defining local variables in Fn::Sub

### DIFF
--- a/Fn.dhall
+++ b/Fn.dhall
@@ -14,7 +14,7 @@ let _Pi =
         , Join : Text → List Fn → Fn
         , Split : Text → Fn → Fn
         , Sub : Text → Fn
-        , SubVars : Text → Map.Type Text Fn → Fn
+        , Sub/Vars : Text → Map.Type Text Fn → Fn
         , Base64 : Fn → Fn
         , Cidr : Fn → Natural → Natural → Fn
         , Select : Natural → Fn → Fn
@@ -40,12 +40,12 @@ let Sub
     : ∀(x : Text) → Fn/Type
     = λ(x : Text) → λ(Fn : Type) → λ(fn : _Pi Fn) → fn.Sub x
 
-let SubVars =
+let Sub/Vars =
       λ(x : Text) →
       λ(vars : Map.Type Text Fn/Type) →
       λ(Fn : Type) →
       λ(fn : _Pi Fn) →
-        fn.SubVars x (Map.map Text Fn/Type Fn (λ(v : Fn/Type) → v Fn fn) vars)
+        fn.Sub/Vars x (Map.map Text Fn/Type Fn (λ(v : Fn/Type) → v Fn fn) vars)
 
 let GetAtt/Type = ∀(x : Text) → Fn/Type
 
@@ -171,7 +171,7 @@ let toJSON =
           , Ref = λ(x : Text) → JSON.object (toMap { Ref = JSON.string x })
           , Sub =
               λ(s : Text) → JSON.object (toMap { `Fn::Sub` = JSON.string s })
-          , SubVars =
+          , Sub/Vars =
               λ(s : Text) →
               λ(vars : Map.Type Text JSON.Type) →
                 JSON.object
@@ -335,10 +335,10 @@ let exampleGetAZs =
           { "Fn::GetAZs": { "Ref": "AWS::Region" } }
           ''
 
-let exampleSubVars =
+let exampleSub/Vars =
         assert
       :   JSON.render
-            (toJSON (SubVars "\${var1}\${var2}hello" (toMap {
+            (toJSON (Sub/Vars "\${var1}\${var2}hello" (toMap {
               var1 = String "abc",
               var2 = String "hi"
               })))
@@ -465,6 +465,7 @@ in  { Ref
     , ImportValue
     , String
     , Sub
+    , Sub/Vars
     , Split
     , GetAtt
     , GetAttOf


### PR DESCRIPTION
Currently `Fn.Sub` only takes 1 argument, but `Fn::Sub` in AWS [can optionally take a map of variables](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html).
```
{ "Fn::Sub" : [ String, { Var1Name: Var1Value, Var2Name: Var2Value } ] }
```
This PR adds a new function to `Fn.dhall`, named `SubVars`, to support this usage. Example:
```dhall
SubVars "\${var1}\${var2}hello"
  ( toMap
    {
      var1 = String "abc",
      var2 = String "hi"
    }
  )
```
I think the naming is probably not appropriate though, as existing function names corresponds to CFN intrinsic functions directly, but this one doesn't. Or are there any ways to incorporate this into the existing `Fn.Sub` function? Any ideas?